### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,13 +23,13 @@ Changelog
    :target: https://coveralls.io/r/themattrix/python-pystrap
 .. |Health| image:: https://landscape.io/github/themattrix/python-pystrap/master/landscape.svg
    :target: https://landscape.io/github/themattrix/python-pystrap/master
-.. |Version| image:: https://pypip.in/version/pystrap/badge.svg?text=version
+.. |Version| image:: https://img.shields.io/pypi/v/pystrap.svg?label=version
    :target: https://pypi.python.org/pypi/pystrap
-.. |Downloads| image:: https://pypip.in/download/pystrap/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/pystrap.svg
    :target: https://pypi.python.org/pypi/pystrap
-.. |Compatibility| image:: https://pypip.in/py_versions/pystrap/badge.svg
+.. |Compatibility| image:: https://img.shields.io/pypi/pyversions/pystrap.svg
    :target: https://pypi.python.org/pypi/pystrap
-.. |Implementations| image:: https://pypip.in/implementation/pystrap/badge.svg
+.. |Implementations| image:: https://img.shields.io/pypi/implementation/pystrap.svg
    :target: https://pypi.python.org/pypi/pystrap
-.. |Format| image:: https://pypip.in/format/pystrap/badge.svg
+.. |Format| image:: https://img.shields.io/pypi/format/pystrap.svg
    :target: https://pypi.python.org/pypi/pystrap


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pystrap))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pystrap`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.